### PR TITLE
Correct URL to delete vesion

### DIFF
--- a/docs/api/delete_version.rst
+++ b/docs/api/delete_version.rst
@@ -22,7 +22,7 @@ is after the operation.
 
 .. code-block:: text
 
-    DELETE /api/v1/titles/{ID}/versions/{VERSION}
+    DELETE /api/v1/titles/{ID}/version/{VERSION}
 
 Response
 --------
@@ -48,6 +48,6 @@ An example using ``curl``:
 
 .. code-block:: bash
 
-    curl https://beta2.communitypatch.com/api/v1/titles/{ID}/versions/{VERSION} \
+    curl https://beta2.communitypatch.com/api/v1/titles/{ID}/version/{VERSION} \
         -X DELETE \
         -H 'Authorization: Bearer {API-KEY}'


### PR DESCRIPTION
There is a typo in the doc. The URL includes `version` and not `versions`.